### PR TITLE
Fixing type annotation error in timepicker.py. Getting rid of the word "tuple" in tuple[int, int, str] it becomes (int, int, str) and works.

### DIFF
--- a/tktimepicker/timepicker.py
+++ b/tktimepicker/timepicker.py
@@ -114,7 +114,7 @@ class AnalogPicker(tkinter.Frame):  # Creates the fully functional clock timepic
     def period(self) -> str:
         return self.spinPicker.period()
 
-    def time(self) -> tuple[int, int, str]:
+    def time(self) -> (int, int, str):
         return self.hours(), self.minutes(), self.period()
 
 
@@ -225,7 +225,7 @@ class SpinTimePickerOld(basetimepicker.SpinBaseClass):
     def period(self) -> str:
         return self._period.get()
 
-    def time(self) -> tuple[int, int, str]:
+    def time(self) -> (int, int, str):
         return self.hours(), self.minutes(), self.period()
 
 
@@ -321,7 +321,7 @@ class SpinTimePickerModern(basetimepicker.SpinBaseClass):
     def period(self) -> str:
         return self._period.period()
 
-    def time(self) -> tuple[int, int, str]:
+    def time(self) -> (int, int, str):
         return self.hours(), self.minutes(), self.period()
 
 


### PR DESCRIPTION
Hey I got this error when running and decided to look through the code. 

```
    Traceback (most recent call last):
      File "guysthing.py", line 2, in <module>
        from tktimepicker import timepicker
      File "/home/fit/.local/lib/python3.8/site-packages/tktimepicker/timepicker.py", line 9, in <module>
        class AnalogPicker(tkinter.Frame):  # Creates the fully functional clock timepicker
    
      File "/home/fit/.local/lib/python3.8/site-packages/tktimepicker/timepicker.py", line 117, in AnalogPicker
        def time(self) -> tuple[int, int, str]:
    TypeError: 'type' object is not subscriptable
```

Don't know if this is the proper way to do type annotations but it runs now. 

![Running](https://i.imgur.com/Q6Oi3tH.png)